### PR TITLE
Remove prod_image: true in build.yml as its an invalid input.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,4 +17,3 @@ jobs:
           repository_name: clamav-mock
           multiarch_build: 'enabled'
           auth_token: ${{ secrets.GITHUB_TOKEN }}
-          prod_image: true


### PR DESCRIPTION
We do this for the private ecr but looks like we don't on public